### PR TITLE
Untitled

### DIFF
--- a/lib/mongo_session_store/mongo_mapper.rb
+++ b/lib/mongo_session_store/mongo_mapper.rb
@@ -20,7 +20,7 @@ module ActionDispatch
 
       private
         def generate_sid
-          BSON::ObjectID.new
+          BSON::ObjectId.new
         end
 
         def get_session(env, sid)
@@ -42,7 +42,7 @@ module ActionDispatch
         def find_session(id)
           @@session_class.find(id) ||
             @@session_class.new(:id=>id)
-        rescue BSON::InvalidObjectID
+        rescue BSON::InvalidObjectId
           @@session_class.new(:id => generate_sid)
         end
 


### PR DESCRIPTION
Latest version of mongo_mapper uses ObjectId instead of ObjectID.
