### PR TITLE
Drop Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - "2.0.0"
   - "2.1.0"
   - "2.2.0"
   - "2.3.0"


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/