### PR TITLE
Remove old rubies, run tests against MongoDB 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,37 @@
 language: ruby
+
 cache: bundler
+
 rvm:
-  - "2.1.0"
-  - "2.2.0"
-  - "2.3.0"
+  - 2.3.1
+  - 2.1.10
+
 gemfile:
-  - "gemfiles/rails-4.0-mongo.gemfile"
-  - "gemfiles/rails-4.0-mongoid.gemfile"
-  - "gemfiles/rails-4.1-mongo.gemfile"
-  - "gemfiles/rails-4.1-mongoid.gemfile"
-  - "gemfiles/rails-4.2-mongo.gemfile"
-  - "gemfiles/rails-4.2-mongoid.gemfile"
+  - gemfiles/rails-4.0-mongo.gemfile
+  - gemfiles/rails-4.0-mongoid.gemfile
+  - gemfiles/rails-4.1-mongo.gemfile
+  - gemfiles/rails-4.1-mongoid.gemfile
+  - gemfiles/rails-4.2-mongo.gemfile
+  - gemfiles/rails-4.2-mongoid.gemfile
+
 matrix:
   fast_finish: true
   include:
-    - rvm: "2.3.0"
-      gemfile: "gemfiles/rails-4.2-mongo.gemfile"
-      script: "bundle exec rubocop"
-    - rvm: "2.3.1"
-      gemfile: "gemfiles/rails-4.2-mongo.gemfile"
-      script: "bundle exec danger"
+    - rvm: 2.3.1
+      gemfile: gemfiles/rails-4.2-mongo.gemfile
+      script: bundle exec rubocop
+    - rvm: 2.3.1
+      gemfile: gemfiles/rails-4.2-mongo.gemfile
+      script: bundle exec danger
 
-before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.1.tgz -O /tmp/mongodb.tgz
-  - tar -xvf /tmp/mongodb.tgz
-  - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-3.0.1/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
+services: mongodb
+
+addons:
+  apt:
+    sources:
+      - mongodb-3.2-precise
+    packages:
+      - mongodb-org-server
 
 script:
-  - "bundle exec rake test"
+  - bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Move session data packing and unpacking to session models. This allows queried documents to unpack session data themselves - [@tombruijn](https://github.com/tombruijn).
 * Test more internal code - [@tombruijn](https://github.com/tombruijn).
 * Allow for easier custom classes and expanded behavior of Mongoid and Mongo session stores - [@tombruijn](https://github.com/tombruijn).
+* [#24](https://github.com/mongoid/mongo_session_store/pull/24): Add Danger, PR linter - [@tombruijn](https://github.com/tombruijn), [@dblock](https://github.com/dblock).
+* [#27](https://github.com/mongoid/mongo_session_store/pull/27): Run tests against Ruby 2.3.1 and MongoDB 3.2 only - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ## 2.0.0


### PR DESCRIPTION
This is on top of #24 not to mess with CHANGELOG, part of #26.  Feels like testing all the Rails against all the Rubies is a bit wasteful.