### PR TITLE
	Support Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.1
   - 2.1.10
+  - 2.3.1
+  - 2.4.1
 
 gemfile:
   - gemfiles/rails-4.0-mongo.gemfile
@@ -23,6 +24,15 @@ matrix:
     - rvm: 2.3.1
       gemfile: gemfiles/rails-4.2-mongo.gemfile
       script: bundle exec danger
+  exclude:
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails-4.0-mongo.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails-4.0-mongoid.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails-4.1-mongo.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails-4.1-mongoid.gemfile
 
 services: mongodb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Allow for easier custom classes and expanded behavior of Mongoid and Mongo session stores - [@tombruijn](https://github.com/tombruijn).
 * [#24](https://github.com/mongoid/mongo_session_store/pull/24): Add Danger, PR linter - [@tombruijn](https://github.com/tombruijn), [@dblock](https://github.com/dblock).
 * [#27](https://github.com/mongoid/mongo_session_store/pull/27): Run tests against Ruby 2.3.1 and MongoDB 3.2 only - [@dblock](https://github.com/dblock).
+* [#28](https://github.com/mongoid/mongo_session_store/pull/28): Support Ruby 2.4 - [@tombruijn](https://github.com/tombruijn).
 * [#29](https://github.com/mongoid/mongo_session_store/pull/29): Use rails default session id generation - [@tombruijn](https://github.com/tombruijn).
 * Your contribution here.
 

--- a/gemfiles/rails-4.0-mongo.gemfile
+++ b/gemfiles/rails-4.0-mongo.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongo"
 
-gem "rails", "4.0"
+gem "rails", "~> 4.0.0"
 gem "devise", "~> 3.5"
 gem "sqlite3"
 

--- a/gemfiles/rails-4.0-mongoid.gemfile
+++ b/gemfiles/rails-4.0-mongoid.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongoid"
 
-gem "rails", "4.0"
+gem "rails", "~> 4.0.0"
 gem "devise", "~> 3.5"
 gem "sqlite3"
 

--- a/gemfiles/rails-4.1-mongo.gemfile
+++ b/gemfiles/rails-4.1-mongo.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongo"
 
-gem "rails", "4.1"
+gem "rails", "~> 4.1.0"
 gem "devise", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1") ? "3.5.10" : ">= 4.2"
 gem "sqlite3"
 

--- a/gemfiles/rails-4.1-mongoid.gemfile
+++ b/gemfiles/rails-4.1-mongoid.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongoid"
 
-gem "rails", "4.1"
+gem "rails", "~> 4.1.0"
 gem "devise", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1") ? "3.5.10" : ">= 4.2"
 gem "sqlite3"
 

--- a/gemfiles/rails-4.2-mongo.gemfile
+++ b/gemfiles/rails-4.2-mongo.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongo"
 
-gem "rails", "4.2"
+gem "rails", "~> 4.2.8"
 gem "devise", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1") ? "3.5.10" : ">= 4.2"
 gem "sqlite3"
 

--- a/gemfiles/rails-4.2-mongoid.gemfile
+++ b/gemfiles/rails-4.2-mongoid.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "mongoid"
 
-gem "rails", "4.2"
+gem "rails", "~> 4.2.8"
 gem "devise", Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1") ? "3.5.10" : ">= 4.2"
 gem "sqlite3"
 


### PR DESCRIPTION
Closes #26 

Older Rails versions, < 4.2, do not support Ruby 2.4, so we exclude them
from the build.