### PR TITLE
Use Rails default session id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Allow for easier custom classes and expanded behavior of Mongoid and Mongo session stores - [@tombruijn](https://github.com/tombruijn).
 * [#24](https://github.com/mongoid/mongo_session_store/pull/24): Add Danger, PR linter - [@tombruijn](https://github.com/tombruijn), [@dblock](https://github.com/dblock).
 * [#27](https://github.com/mongoid/mongo_session_store/pull/27): Run tests against Ruby 2.3.1 and MongoDB 3.2 only - [@dblock](https://github.com/dblock).
+* [#29](https://github.com/mongoid/mongo_session_store/pull/29): Use Rails default session id generation
 * Your contribution here.
 
 ## 2.0.0

--- a/lib/mongo_session_store/mongo_store_base.rb
+++ b/lib/mongo_session_store/mongo_store_base.rb
@@ -16,10 +16,6 @@ module ActionDispatch
         self.class.session_class
       end
 
-      def generate_sid
-        BSON::ObjectId.new.to_s
-      end
-
       def get_session(env, sid)
         id, record = find_or_initialize_session(sid)
         env[SESSION_RECORD_KEY] = record
@@ -40,7 +36,7 @@ module ActionDispatch
         existing_session = (id && session_class.where(:_id => id).first)
         session = existing_session if existing_session
         session ||= session_class.new(:_id => generate_sid)
-        [session._id.to_s, session]
+        [session._id, session]
       end
 
       def get_session_record(env, sid)

--- a/spec/lib/mongo_session_store/mongo_store/session_spec.rb
+++ b/spec/lib/mongo_session_store/mongo_store/session_spec.rb
@@ -62,11 +62,11 @@ if mongo_orm == "mongo"
       end
 
       context "with matching records" do
-        let(:session) { described_class.new(:_id => BSON::ObjectId.new).tap(&:save) }
+        let(:session) { described_class.new(:_id => generate_sid).tap(&:save) }
         let(:id) { session._id }
         before do
           # Noise
-          described_class.new(:_id => BSON::ObjectId.new).tap(&:save)
+          described_class.new(:_id => generate_sid).tap(&:save)
         end
 
         it "returns session model objects" do
@@ -83,14 +83,14 @@ if mongo_orm == "mongo"
       context "without data" do
         let(:attributes) do
           {
-            :_id => BSON::ObjectId.new,
+            :_id => generate_sid,
             :created_at => created_at,
             :updated_at => updated_at
           }
         end
 
         it "creates a session object with empty data" do
-          expect(session._id).to be_kind_of(BSON::ObjectId)
+          expect(session._id).to be_kind_of(String)
           expect(session.data).to eq({})
           expect(session.created_at).to eq(created_at)
           expect(session.updated_at).to eq(updated_at)
@@ -100,7 +100,7 @@ if mongo_orm == "mongo"
       context "with data key as a symbol" do
         let(:attributes) do
           {
-            :_id => BSON::ObjectId.new,
+            :_id => generate_sid,
             :data => BSON::Binary.new(Marshal.dump(:foo => "bar"), :generic),
             :created_at => created_at,
             :updated_at => updated_at
@@ -108,7 +108,7 @@ if mongo_orm == "mongo"
         end
 
         it "creates a session object with correct data" do
-          expect(session._id).to be_kind_of(BSON::ObjectId)
+          expect(session._id).to be_kind_of(String)
           expect(session.data).to eq(:foo => "bar")
           expect(session.created_at).to eq(created_at)
           expect(session.updated_at).to eq(updated_at)
@@ -118,7 +118,7 @@ if mongo_orm == "mongo"
       context "with data key as a string" do
         let(:attributes) do
           {
-            :_id => BSON::ObjectId.new,
+            :_id => generate_sid,
             "data" => BSON::Binary.new(Marshal.dump(:foo => "bar"), :generic),
             :created_at => created_at,
             :updated_at => updated_at
@@ -126,7 +126,7 @@ if mongo_orm == "mongo"
         end
 
         it "creates a session object with correct data" do
-          expect(session._id).to be_kind_of(BSON::ObjectId)
+          expect(session._id).to be_kind_of(String)
           expect(session.data).to eq(:foo => "bar")
           expect(session.created_at).to eq(created_at)
           expect(session.updated_at).to eq(updated_at)
@@ -135,7 +135,7 @@ if mongo_orm == "mongo"
     end
 
     describe "#save" do
-      let(:id) { BSON::ObjectId.new }
+      let(:id) { generate_sid }
       subject { described_class.collection.find(:_id => id).first }
 
       describe "_id attribute" do
@@ -235,7 +235,7 @@ if mongo_orm == "mongo"
     end
 
     describe "#destroy" do
-      let(:id) { BSON::ObjectId.new }
+      let(:id) { generate_sid }
       let(:session) { described_class.new(:_id => id) }
       before { session.save }
 

--- a/spec/lib/mongo_session_store/mongo_store_base_spec.rb
+++ b/spec/lib/mongo_session_store/mongo_store_base_spec.rb
@@ -99,10 +99,10 @@ describe ActionDispatch::Session::MongoStoreBase do
     let(:store_class) { mongo_orm == "mongoid" ? MongoidStore : MongoStore }
     let(:store) { store_class.new(nil) }
     let(:session_class) { store_class::Session }
-    subject { store.send(:set_session, env, BSON::ObjectId.new, {}) }
+    subject { store.send(:set_session, env, generate_sid, {}) }
 
     context "with existing session record" do
-      let(:id) { BSON::ObjectId.new }
+      let(:id) { generate_sid }
       let!(:session_record) { session_class.new(:_id => id).tap(&:save) }
       let(:env) do
         {
@@ -182,7 +182,7 @@ describe ActionDispatch::Session::MongoStoreBase do
   end
 
   describe "#destroy_session" do
-    let(:id) { BSON::ObjectId.new }
+    let(:id) { generate_sid }
     let(:store_class) { mongo_orm == "mongoid" ? MongoidStore : MongoStore }
     let(:store) { store_class.new(nil) }
     let(:session_class) { store_class::Session }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "mongo"
 require "mongoid" if Gem.loaded_specs["mongoid"]
 require "mongo_session_store"
 require "support/helpers/test_database_helper"
+require "support/helpers/session_id_helper"
 
 def mongo_orm
   defined?(Mongoid) ? "mongoid" : "mongo"
@@ -9,6 +10,7 @@ end
 
 RSpec.configure do |config|
   config.include TestDatabaseHelper
+  config.include SessionIdHelper
 
   config.order = "random"
   config.mock_with :rspec do |c|

--- a/spec/support/helpers/session_id_helper.rb
+++ b/spec/support/helpers/session_id_helper.rb
@@ -1,0 +1,5 @@
+module SessionIdHelper
+  def generate_sid
+    ActionDispatch::Session::MongoStoreBase.new(nil).generate_sid
+  end
+end


### PR DESCRIPTION
`BSON::ObjectId` is too sequential so can be more easily guessed.
https://docs.mongodb.com/manual/reference/method/ObjectId/

Since the session cookie is not encrypted a user can modify the cookie
and guess another user's session id based on their own.

This change uses the Rails default session id generation using
`SecureRandom.hex(16)`.

Closes #23 