### PR TITLE
Fix build by including Capybara as dependency

### DIFF
--- a/mongo_session_store.gemspec
+++ b/mongo_session_store.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mongo", "~> 2.0"
 
   s.add_development_dependency "rspec-rails", "~> 3.6"
+  s.add_development_dependency "capybara", "~> 2.15.0"
   s.add_development_dependency "pry", "~> 0.10"
   s.add_development_dependency "rake", "~> 11"
   s.add_development_dependency "rubocop", "0.45.0"


### PR DESCRIPTION
With rspec-rails 2.x this was a dependency, with 3.x we need to include
it manually.