### PR TITLE
Add gem specific main error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2.0 (unreleased)
 
 * [#32](https://github.com/mongoid/mongo_session_store/pull/32): Add Rails 5.1 support - [@tombruijn](https://github.com/tombruijn).
+* [#36](https://github.com/mongoid/mongo_session_store/pull/36): Add gem specific main error class - [@tombruijn](https://github.com/tombruijn).
 * Your contribution here.
 
 ## 3.1.0

--- a/lib/mongo_session_store.rb
+++ b/lib/mongo_session_store.rb
@@ -1,4 +1,6 @@
 module MongoSessionStore
+  class Error < StandardError; end
+
   def self.collection_name
     @collection_name
   end

--- a/lib/mongo_session_store/mongo_store.rb
+++ b/lib/mongo_session_store/mongo_store.rb
@@ -47,7 +47,7 @@ module ActionDispatch
           end
         end
 
-        class NoMongoClientError < StandardError; end
+        class NoMongoClientError < ::MongoSessionStore::Error; end
 
         attr_accessor :_id, :data, :created_at, :updated_at
 


### PR DESCRIPTION
Makes it easier to rescue all errors from this gem, currently only one,
rather than having to specify them all in the rescue statement.

```
begin
  # do stuff
rescue MongoSessionStore::Error => e
  # e == ActionDispatch::Session::MongoStore::Session::NoMongoClientError
end
```