### PR TITLE
Support Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ gemfile:
   - gemfiles/rails-5.0-mongoid.gemfile
   - gemfiles/rails-5.1-mongo.gemfile
   - gemfiles/rails-5.1-mongoid.gemfile
+  - gemfiles/rails-5.2-mongo.gemfile
+  - gemfiles/rails-5.2-mongoid.gemfile
 
 matrix:
   fast_finish: true
@@ -49,6 +51,10 @@ matrix:
       gemfile: gemfiles/rails-5.1-mongo.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails-5.1-mongoid.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails-5.2-mongo.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails-5.2-mongoid.gemfile
 
 services: mongodb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#32](https://github.com/mongoid/mongo_session_store/pull/32): Add Rails 5.1 support - [@tombruijn](https://github.com/tombruijn).
 * [#36](https://github.com/mongoid/mongo_session_store/pull/36): Add gem specific main error class - [@tombruijn](https://github.com/tombruijn).
+* [#38](https://github.com/mongoid/mongo_session_store/pull/38): Support rails 5.2 - [@tombruijn](https://github.com/tombruijn).
 * Your contribution here.
 
 ## 3.1.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MongoSessionStore is a [Rails][rails]-compatible session store for
 Driver][mongo]. It also allows for custom Mongo session store that works with
 any (or no!) Mongo ODM.
 
-MongoSessionStore version 3 is compatible with Rails 4.0 through 5.1. For Rails
+MongoSessionStore version 3 is compatible with Rails 4.0 through 5.2. For Rails
 3 support please check out issue [#17][issue-rails3] for options and let us
 know if you need support.
 
@@ -92,6 +92,8 @@ BUNDLE_GEMFILE=gemfiles/rails-5.0-mongo.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails-5.0-mongoid.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails-5.1-mongo.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails-5.1-mongoid.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails-5.2-mongo.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails-5.2-mongoid.gemfile bundle exec rake
 ```
 
 ### Performance benchmark

--- a/gemfiles/rails-5.2-mongo.gemfile
+++ b/gemfiles/rails-5.2-mongo.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "mongo"
+
+gem "rails", "~> 5.2.0"
+gem "devise", "~> 4.6.2"
+gem "sqlite3", "~> 1.3.6"
+
+gemspec :path => "../"

--- a/gemfiles/rails-5.2-mongoid.gemfile
+++ b/gemfiles/rails-5.2-mongoid.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "mongoid"
+
+gem "rails", "~> 5.2.0"
+gem "devise", "~> 4.6.2"
+gem "sqlite3", "~> 1.3.6"
+
+gemspec :path => "../"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,10 @@
 ENV["RAILS_ENV"] = "test"
+rails_version = Gem.loaded_specs["rails"].version.to_s[/^\d\.\d/]
+if Gem.loaded_specs["rails"].version >= Gem::Version.new("5.2")
+  require "active_support/message_encryptor"
+end
 require "spec_helper"
 require "rails"
-rails_version = Gem.loaded_specs["rails"].version.to_s[/^\d\.\d/]
 require "support/apps/rails_#{rails_version}_app/config/environment"
 require "rspec/rails"
 

--- a/spec/support/apps/rails_5.2_app/Rakefile
+++ b/spec/support/apps/rails_5.2_app/Rakefile
@@ -1,0 +1,6 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require_relative 'config/application'
+
+Rails.application.load_tasks

--- a/spec/support/apps/rails_5.2_app/app/controllers/application_controller.rb
+++ b/spec/support/apps/rails_5.2_app/app/controllers/application_controller.rb
@@ -1,0 +1,3 @@
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+end

--- a/spec/support/apps/rails_5.2_app/app/controllers/home_controller.rb
+++ b/spec/support/apps/rails_5.2_app/app/controllers/home_controller.rb
@@ -1,0 +1,2 @@
+class HomeController < ApplicationController
+end

--- a/spec/support/apps/rails_5.2_app/app/models/application_record.rb
+++ b/spec/support/apps/rails_5.2_app/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/spec/support/apps/rails_5.2_app/app/models/user.rb
+++ b/spec/support/apps/rails_5.2_app/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable
+end

--- a/spec/support/apps/rails_5.2_app/app/views/home/index.html.erb
+++ b/spec/support/apps/rails_5.2_app/app/views/home/index.html.erb
@@ -1,0 +1,9 @@
+You are signed
+<% if user_signed_in? %>
+  in as <%= current_user.email %>.
+  <%= form_tag destroy_user_session_path, :method => :delete do %>
+    <%= button_tag "Sign out" %>
+  <% end %>
+<% else %>
+  out.  <%= link_to "Sign in", new_user_session_path %>
+<% end %>

--- a/spec/support/apps/rails_5.2_app/app/views/layouts/application.html.erb
+++ b/spec/support/apps/rails_5.2_app/app/views/layouts/application.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Rails52App</title>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+
+<%= notice %>
+<%= alert %>
+
+<%= yield %>
+
+</body>
+</html>

--- a/spec/support/apps/rails_5.2_app/bin/bundle
+++ b/spec/support/apps/rails_5.2_app/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/spec/support/apps/rails_5.2_app/bin/rails
+++ b/spec/support/apps/rails_5.2_app/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/spec/support/apps/rails_5.2_app/bin/rake
+++ b/spec/support/apps/rails_5.2_app/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run

--- a/spec/support/apps/rails_5.2_app/bin/setup
+++ b/spec/support/apps/rails_5.2_app/bin/setup
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+require 'pathname'
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file.
+
+  puts '== Installing dependencies =='
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?('config/database.yml')
+  #   cp 'config/database.yml.sample', 'config/database.yml'
+  # end
+
+  puts "\n== Preparing database =="
+  system! 'bin/rails db:setup'
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rails log:clear tmp:clear'
+
+  puts "\n== Restarting application server =="
+  system! 'bin/rails restart'
+end

--- a/spec/support/apps/rails_5.2_app/bin/update
+++ b/spec/support/apps/rails_5.2_app/bin/update
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require 'pathname'
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  # This script is a way to update your development environment automatically.
+  # Add necessary update steps to this file.
+
+  puts '== Installing dependencies =='
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
+
+  puts "\n== Updating database =="
+  system! 'bin/rails db:migrate'
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rails log:clear tmp:clear'
+
+  puts "\n== Restarting application server =="
+  system! 'bin/rails restart'
+end

--- a/spec/support/apps/rails_5.2_app/config.ru
+++ b/spec/support/apps/rails_5.2_app/config.ru
@@ -1,0 +1,5 @@
+# This file is used by Rack-based servers to start the application.
+
+require_relative 'config/environment'
+
+run Rails.application

--- a/spec/support/apps/rails_5.2_app/config/application.rb
+++ b/spec/support/apps/rails_5.2_app/config/application.rb
@@ -5,8 +5,8 @@ require "active_record/railtie"
 
 Bundler.require(*Rails.groups)
 
-module Rails51App
+module Rails52App
   class Application < Rails::Application
-    config.load_defaults 5.1
+    config.load_defaults 5.2
   end
 end

--- a/spec/support/apps/rails_5.2_app/config/boot.rb
+++ b/spec/support/apps/rails_5.2_app/config/boot.rb
@@ -1,0 +1,5 @@
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/spec/support/apps/rails_5.2_app/config/database.yml
+++ b/spec/support/apps/rails_5.2_app/config/database.yml
@@ -1,0 +1,11 @@
+test:
+  adapter: <%= RUBY_PLATFORM == "java" ? "jdbcsqlite3" : "sqlite3" %>
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  adapter: <%= RUBY_PLATFORM == "java" ? "jdbcsqlite3" : "sqlite3" %>
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000

--- a/spec/support/apps/rails_5.2_app/config/environment.rb
+++ b/spec/support/apps/rails_5.2_app/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/spec/support/apps/rails_5.2_app/config/environments/development.rb
+++ b/spec/support/apps/rails_5.2_app/config/environments/development.rb
@@ -1,0 +1,12 @@
+Rails.application.configure do
+  config.cache_classes = false
+
+  config.eager_load = false
+
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  config.active_support.deprecation = :log
+
+  config.active_record.migration_error = :page_load
+end

--- a/spec/support/apps/rails_5.2_app/config/environments/test.rb
+++ b/spec/support/apps/rails_5.2_app/config/environments/test.rb
@@ -1,0 +1,19 @@
+Rails.application.configure do
+  config.cache_classes = true
+
+  config.eager_load = false
+
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  config.action_dispatch.show_exceptions = false
+
+  config.action_controller.allow_forgery_protection = false
+
+  config.active_support.test_order = :random
+
+  config.active_support.deprecation = :stderr
+end

--- a/spec/support/apps/rails_5.2_app/config/initializers/devise.rb
+++ b/spec/support/apps/rails_5.2_app/config/initializers/devise.rb
@@ -1,0 +1,254 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # config.secret_key = '8520db904cf1def8752b3f9e5e0e2e1e88f2a5545d894ad073e93b6da6bad1228d09cd3ab5b9566a55b74d3bea699d87c17414c52a54c0644bb6810a5bbca3e2'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [ :email ]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [ :email ]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [ :email ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If http headers should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing :skip => :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments.
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Setup a pepper to generate the encrypted password.
+  # config.pepper = '30efc0523d0953dad5356bac16efa34f7d10176e193a6dcbd69ed1bd459dfcb4b3bdcec895d62519bcd6c5f6104070a13875933ab7439c1e3735341c9ee595df'
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed new email is stored in
+  # unconfirmed email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # :secure => true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 8..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # If true, expires auth token on session timeout.
+  # config.expire_auth_token_on_timeout = false
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [ :email ]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = false
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [ :email ]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+  # REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using omniauth, Devise cannot automatically set Omniauth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/spec/support/apps/rails_5.2_app/config/initializers/session_store.rb
+++ b/spec/support/apps/rails_5.2_app/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :"#{mongo_orm}_store"

--- a/spec/support/apps/rails_5.2_app/config/locales/en.yml
+++ b/spec/support/apps/rails_5.2_app/config/locales/en.yml
@@ -1,0 +1,23 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+en:
+  hello: "Hello world"

--- a/spec/support/apps/rails_5.2_app/config/mongo.yml
+++ b/spec/support/apps/rails_5.2_app/config/mongo.yml
@@ -1,0 +1,11 @@
+defaults: &defaults
+  host: 127.0.0.1
+  port: 27017
+
+development:
+  <<: *defaults
+  database: test_database
+
+test:
+  <<: *defaults
+  database: test_database

--- a/spec/support/apps/rails_5.2_app/config/mongoid.yml
+++ b/spec/support/apps/rails_5.2_app/config/mongoid.yml
@@ -1,0 +1,13 @@
+development:
+  clients:
+    default:
+      database: test_database
+      hosts:
+        - 127.0.0.1:27017
+
+test:
+  clients:
+    default:
+      database: test_database
+      hosts:
+        - 127.0.0.1:27017

--- a/spec/support/apps/rails_5.2_app/config/routes.rb
+++ b/spec/support/apps/rails_5.2_app/config/routes.rb
@@ -1,0 +1,4 @@
+Rails.application.routes.draw do
+  devise_for :users
+  root :to => "home#index"
+end

--- a/spec/support/apps/rails_5.2_app/config/secrets.yml
+++ b/spec/support/apps/rails_5.2_app/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: cef010831c3c4a0f52653b0a5664ceb8091b9dcfb5feabe3ffcc0e08c006d70414dfb3cd1ba9d1273fe2f49f6b9938a7c22605647e783ce04f08415acc07d887
+
+test:
+  secret_key_base: a7f1932ee2f6b72991e40ff14bf4ee16030a9f00fe2294054d39a186be297424a69034528966a2ee61ab959131137bcd7f6ba80491684da11a17c8f7af661abb
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/spec/support/apps/rails_5.2_app/db/migrate/20140301171212_add_devise_users.rb
+++ b/spec/support/apps/rails_5.2_app/db/migrate/20140301171212_add_devise_users.rb
@@ -1,0 +1,11 @@
+class AddDeviseUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table(:users) do |t|
+      t.string :email,              :null => false, :default => ""
+      t.string :encrypted_password, :null => false, :default => ""
+      t.timestamps
+    end
+
+    add_index :users, :email,                :unique => true
+  end
+end

--- a/spec/support/apps/rails_5.2_app/db/schema.rb
+++ b/spec/support/apps/rails_5.2_app/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2014_03_01_171212) do
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+end


### PR DESCRIPTION
Add example app and add it to the build to see if any additional changes
are required.

Need to require the MessageEncryptor class as Rails errors if it's not
required. This may be a bug? The MessageVerifier is loaded by Rails in
the same file as would raise an "uninitialized constant" error.

```
Failure/Error: require "action_dispatch/middleware/session/abstract_store"

NameError:
  uninitialized constant ActiveSupport::MessageEncryptor
  Did you mean?  ActiveSupport::MessageVerifier
```

Requiring it manually in spec fixes the test suite for Rails 5.2.
Running the test app manually works fine, something is off in the load
order.