### PR TITLE
Do not build every branch automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+  - develop
 language: ruby
 
 cache: bundler


### PR DESCRIPTION
Only build the master and develop branches automatically. Prevents
double CI builds from triggering for every PR.