### PR TITLE
Fix Rack::Session::Id usage issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (unreleased)
 
 * [#45](https://github.com/mongoid/mongo_session_store/pull/45): Add Rails 6.0 to test setup - [@tombruijn](https://github.com/tombruijn).
+* [#46](https://github.com/mongoid/mongo_session_store/pull/46): Fix Rack::Session::Cookie middleware bug - [@streetlogics](https://github.com/streetlogics) & [@tombruijn](https://github.com/tombruijn).
 * Your contribution here.
 
 ## 3.2.0

--- a/lib/mongo_session_store/mongo_store_base.rb
+++ b/lib/mongo_session_store/mongo_store_base.rb
@@ -46,7 +46,7 @@ module ActionDispatch
       end
 
       def find_or_initialize_session(id)
-        existing_session = (id && session_class.where(:_id => id).first)
+        existing_session = (id && session_class.where(:_id => id.to_s).first)
         session = existing_session if existing_session
         session ||= session_class.new(:_id => generate_sid)
         [session._id, session]

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "Rack app", :type => :request do
+  it "works with a mounted Rack app using Rack::Session" do
+    if Gem.loaded_specs["rack"].version < Gem::Version.new("2.0.0")
+      # Fails on trying to stringify the Rack::Session::Id object. Unrelated to
+      # this gem's code.
+      #
+      #   NoMethodError:
+      #   undefined method `each' for #<ActionDispatch::Request::Session:...>
+      #
+      # Skip spec setup for older Rack versions.
+      skip "Incompatible Rack version"
+    end
+
+    get "/rack_test"
+    expect(response.body.squish).to eql("Hello Rack app!")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ if Gem.loaded_specs["rails"].version >= Gem::Version.new("5.2")
 end
 require "spec_helper"
 require "rails"
+require "support/rack_app"
 require "support/apps/rails_#{rails_version}_app/config/environment"
 require "rspec/rails"
 

--- a/spec/support/apps/rails_4.0_app/config/routes.rb
+++ b/spec/support/apps/rails_4.0_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails40App::Application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_4.1_app/config/routes.rb
+++ b/spec/support/apps/rails_4.1_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_4.2_app/config/routes.rb
+++ b/spec/support/apps/rails_4.2_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_5.0_app/config/routes.rb
+++ b/spec/support/apps/rails_5.0_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_5.1_app/config/routes.rb
+++ b/spec/support/apps/rails_5.1_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_5.2_app/config/routes.rb
+++ b/spec/support/apps/rails_5.2_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/apps/rails_6.0_app/config/routes.rb
+++ b/spec/support/apps/rails_6.0_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  mount MyAppWrapped => "/rack_test"
   root :to => "home#index"
 end

--- a/spec/support/rack_app.rb
+++ b/spec/support/rack_app.rb
@@ -1,0 +1,14 @@
+class MyApp
+  def call(_env)
+    [
+      200,
+      { "Content-Type" => "text/html" },
+      ["Hello Rack app!"]
+    ]
+  end
+end
+
+MyAppWrapped = Rack::Builder.new do |builder|
+  builder.use Rack::Session::Cookie, :secret => "Very secret secret"
+  builder.run MyApp.new
+end


### PR DESCRIPTION
Caused by using a Rack app with the Rack::Session::Cookie middleware.
The `id` is then a Rack::Session::Id instead of a String.

Fixes #42
Follow up of #43
